### PR TITLE
lein-ring: Upgrade the lein-ring dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.clojure/data.json "0.2.4"]
                  [compojure "1.1.6"]]
-  :plugins [[lein-ring "0.8.10"]]
+  :plugins [[lein-ring "0.12.5"]]
   :ring {:handler fontmanager.handler/app}
   :profiles
   {:dev {:dependencies [[javax.servlet/servlet-api "2.5"]


### PR DESCRIPTION
When trying to run the ring server, an error was encountered similar to the
issue reported here.

  https://github.com/weavejester/lein-ring/issues/207

The fix is to use the latest version of lein-ring.

Testing:

Software appears to run correctly with 'lein ring server' when this change is
made.